### PR TITLE
Add in deeplinking support

### DIFF
--- a/wikipedia-ios/Wikipedia/Code/NSUserActivity+WMFExtensions.h
+++ b/wikipedia-ios/Wikipedia/Code/NSUserActivity+WMFExtensions.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <CoreLocation/CoreLocation.h>
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSUInteger, WMFUserActivityType) {
@@ -45,6 +46,8 @@ extern NSString *const WMFNavigateToActivityNotification;
 - (nullable NSString *)wmf_searchTerm;
 
 - (nullable NSURL *)wmf_linkURL;
+
+- (nullable CLLocation *)wmf_locationFromURL;
 
 - (NSURL *)wmf_contentURL;
 

--- a/wikipedia-ios/Wikipedia/Code/NSUserActivity+WMFExtensions.m
+++ b/wikipedia-ios/Wikipedia/Code/NSUserActivity+WMFExtensions.m
@@ -53,6 +53,22 @@ __attribute__((annotate("returns_localized_nsstring"))) static inline NSString *
     return activity;
 }
 
++ (instancetype)wmf_pageActivityWithName:(NSString *)pageName latitude:(NSNumber *)latitude longitude:(NSNumber *)longitude  {
+    NSUserActivity *activity = [self wmf_activityWithType:[pageName lowercaseString]];
+    activity.title = wmf_localizationNotNeeded(pageName);
+    if (latitude != nil && longitude != nil) {
+        activity.userInfo = @{@"WMFPage": pageName, @"latitude": latitude, @"longitude": longitude};
+    } else {
+        activity.userInfo = @{@"WMFPage": pageName};
+    }
+
+    NSMutableSet *set = [activity.keywords mutableCopy];
+    [set addObjectsFromArray:[pageName componentsSeparatedByString:@" "]];
+    activity.keywords = set;
+
+    return activity;
+}
+
 + (instancetype)wmf_contentActivityWithURL:(NSURL *)url {
     NSUserActivity *activity = [self wmf_activityWithType:@"Content"];
     activity.userInfo = @{@"WMFURL": url};
@@ -62,14 +78,27 @@ __attribute__((annotate("returns_localized_nsstring"))) static inline NSString *
 + (instancetype)wmf_placesActivityWithURL:(NSURL *)activityURL {
     NSURLComponents *components = [NSURLComponents componentsWithURL:activityURL resolvingAgainstBaseURL:NO];
     NSURL *articleURL = nil;
+    NSNumber *lat = nil;
+    NSNumber *lon = nil;
+    NSNumberFormatter *coordsFormatter = [[NSNumberFormatter alloc] init];
+    coordsFormatter.maximumFractionDigits = 16; //accounts for twice beyond the recommended max of 8 digits for 1mm precision
+    
     for (NSURLQueryItem *item in components.queryItems) {
         if ([item.name isEqualToString:@"WMFArticleURL"]) {
             NSString *articleURLString = item.value;
             articleURL = [NSURL URLWithString:articleURLString];
             break;
         }
+        
+        if ([item.name isEqualToString:@"lat"]) {
+            lat = [coordsFormatter numberFromString:item.value];
+        }
+        
+        if ([item.name isEqualToString:@"lon"]) {
+            lon = [coordsFormatter numberFromString:item.value];
+        }
     }
-    NSUserActivity *activity = [self wmf_pageActivityWithName:@"Places"];
+    NSUserActivity *activity = [self wmf_pageActivityWithName:@"Places" latitude:lat longitude:lon];
     activity.webpageURL = articleURL;
     return activity;
 }
@@ -266,6 +295,17 @@ __attribute__((annotate("returns_localized_nsstring"))) static inline NSString *
 
 - (NSURL *)wmf_contentURL {
     return self.userInfo[@"WMFURL"];
+}
+
+- (CLLocation *)wmf_locationFromURL {
+    NSNumber *lat = self.userInfo[@"latitude"];
+    NSNumber *lon = self.userInfo[@"longitude"];
+    if (lat != nil && lon != nil) {
+        CLLocationDegrees latDegrees = (CLLocationDegrees)[lat floatValue];
+        CLLocationDegrees lonDegrees = (CLLocationDegrees)[lon floatValue];
+        return [[CLLocation alloc] initWithLatitude:latDegrees longitude:lonDegrees];
+    }
+    return nil;
 }
 
 + (NSURLComponents *)wmf_baseURLComponentsForActivityOfType:(WMFUserActivityType)type {

--- a/wikipedia-ios/Wikipedia/Code/PlacesViewController.swift
+++ b/wikipedia-ios/Wikipedia/Code/PlacesViewController.swift
@@ -1244,7 +1244,11 @@ class PlacesViewController: ArticleLocationCollectionViewController, UISearchBar
         mapView.selectAnnotation(articlePlace, animated: articlePlace.identifier != previouslySelectedArticlePlaceIdentifier)
         previouslySelectedArticlePlaceIdentifier = articlePlace.identifier
     }
-
+    
+    @objc func centerMap(location: CLLocation) {
+        self.zoomAndPanMapView(toLocation: location)
+    }
+    
     // MARK: - Search History
 
     fileprivate func searchHistoryGroup(forFilter: PlaceFilterType) -> String {

--- a/wikipedia-ios/Wikipedia/Code/WMFAppViewController.m
+++ b/wikipedia-ios/Wikipedia/Code/WMFAppViewController.m
@@ -1232,10 +1232,20 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
             [self setSelectedIndex:WMFAppTabTypePlaces];
             [self.currentTabNavigationController popToRootViewControllerAnimated:animated];
             NSURL *articleURL = activity.wmf_linkURL;
+            CLLocation *locationFromURL = activity.wmf_locationFromURL;
             if (articleURL) {
                 // For "View on a map" action to succeed, view mode has to be set to map.
                 [[self placesViewController] updateViewModeToMap];
                 [[self placesViewController] showArticleURL:articleURL];
+            } else if (locationFromURL) {
+                [[self placesViewController] updateViewModeToMap];
+                
+                // let the map have time to load before centering
+                NSTimeInterval delayInSeconds = 1.0;
+                dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
+                dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+                    [[self placesViewController] centerMapWithLocation:locationFromURL];
+                });
             }
         } break;
         case WMFUserActivityTypeContent: {

--- a/wikipedia-ios/WikipediaUnitTests/Code/NSUserActivity+WMFExtensionsTest.m
+++ b/wikipedia-ios/WikipediaUnitTests/Code/NSUserActivity+WMFExtensionsTest.m
@@ -52,5 +52,95 @@
                           @"https://en.wikipedia.org/w/index.php?search=dog&title=Special:Search&fulltext=1");
 }
 
+-(void)testPlacesURL {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://places"];
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertNil(activity.webpageURL);
+    XCTAssertNil(activity.userInfo[@"latitude"]);
+    XCTAssertNil(activity.userInfo[@"longitude"]);
+}
+
+-(void)testPlacesURLWithLatitudeThenLongitude {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://places?lat=52.3547498&lon=4.8339215"]; // Amsterdam coords from JSON
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertNil(activity.webpageURL);
+    XCTAssert([activity.userInfo[@"latitude"] isEqualToNumber:@52.3547498]);
+    XCTAssert([activity.userInfo[@"longitude"] isEqualToNumber:@4.8339215]);
+}
+
+-(void)testPlacesURLWithLongitudeThenLatitude {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://places?lon=4.8339215&lat=52.3547498"]; // Amsterdam coords from JSON
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertNil(activity.webpageURL);
+    XCTAssert([activity.userInfo[@"latitude"] isEqualToNumber:@52.3547498]);
+    XCTAssert([activity.userInfo[@"longitude"] isEqualToNumber:@4.8339215]);
+}
+
+-(void)testPlacesURLWithOnlyLatitude {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://places?lat=52.3547498"]; // Amsterdam coords from JSON
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertNil(activity.webpageURL);
+    XCTAssertNil(activity.userInfo[@"latitude"]);
+    XCTAssertNil(activity.userInfo[@"longitude"]);
+}
+
+-(void)testPlacesURLWithOnlyLongitude {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://places?lon=4.8339215"]; // Amsterdam coords from JSON
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertNil(activity.webpageURL);
+    XCTAssertNil(activity.userInfo[@"latitude"]);
+    XCTAssertNil(activity.userInfo[@"longitude"]);
+}
+
+-(void)testPlacesURLWithEmptyLatitude {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://places?lat=&lon=4.8339215"]; // Amsterdam coords from JSON
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertNil(activity.webpageURL);
+    XCTAssertNil(activity.userInfo[@"latitude"]);
+    XCTAssertNil(activity.userInfo[@"longitude"]);
+}
+
+-(void)testPlacesURLWithEmptyLongitude {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://places?lat=52.3547498&lon="]; // Amsterdam coords from JSON
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertNil(activity.webpageURL);
+    XCTAssertNil(activity.userInfo[@"latitude"]);
+    XCTAssertNil(activity.userInfo[@"longitude"]);
+}
+
+-(void)testPlacesURLWithEmptyLatitudeAndEmptyLongitude {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://places?lat=&lon="];
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertNil(activity.webpageURL);
+    XCTAssertNil(activity.userInfo[@"latitude"]);
+    XCTAssertNil(activity.userInfo[@"longitude"]);
+}
+
+-(void)testPlacesURLWithNegativeLatitudeAndNegativeLongitude {
+    NSURL *url = [NSURL URLWithString:@"wikipedia://places?lat=-13.162968954389248&lon=-72.54470420525286"]; // Macu Pichu
+    NSUserActivity *activity = [NSUserActivity wmf_activityForWikipediaScheme:url];
+    
+    XCTAssertEqual(activity.wmf_type, WMFUserActivityTypePlaces);
+    XCTAssertNil(activity.webpageURL);
+    XCTAssert([activity.userInfo[@"latitude"] isEqualToNumber:@-13.162968954389248]);
+    XCTAssert([activity.userInfo[@"longitude"] isEqualToNumber:@-72.54470420525286]);
+}
+
 @end
 


### PR DESCRIPTION
This PR adds in the deeplinking support.

For now, this is a very basic approach and is designed to deliver the minimum requirements for the project.

Future issues to consider would be:
- leveraging an additional URL scheme that could support providing comma separated values in `coordinates` query param
- ensuring that the `wmf_pageActivityWithName` is not overloaded, but rather a more elegant approach to pass in optional params to allow a single method to exist
- improved testing of other NSUserActivities